### PR TITLE
Preparation for v3.22.1

### DIFF
--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -9,7 +9,7 @@ url="https://www.syslog-ng.com/products/open-source-log-management/"
 license=('GPL2' 'LGPL2.1')
 depends=('awk' 'systemd-libs' 'glib2' 'libnsl' 'json-c' 'curl' 'libnet')
 makedepends=('libxslt' 'mongo-c-driver' 'librabbitmq-c' 'python' 'libesmtp' 'hiredis'
-             'libdbi' 'geoip' 'libmaxminddb')
+             'libdbi' 'geoip' 'libmaxminddb' 'net-snmp')
 checkdepends=('python-nose' 'python-pylint' 'python-ply')
 optdepends=('logrotate: for rotating log files'
             'libdbi: for the SQL plugin'
@@ -20,6 +20,7 @@ optdepends=('logrotate: for rotating log files'
             'hiredis: for the Redis plugin'
             'geoip: for the GeoIP plugin'
             'libmaxminddb: for the GeoIP2 plugin'
+            'net-snmp: for the SNMP plugin'
             'python: for Python-based plugins')
 conflicts=('eventlog')
 replaces=('eventlog')

--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -48,7 +48,7 @@ build() {
     --with-pidfile-dir=/run --enable-spoof-source --enable-ipv6 \
     --enable-systemd --with-systemdsystemunitdir=/usr/lib/systemd/system \
     --enable-manpages --enable-all-modules --disable-java --disable-java-modules  \
-    --disable-riemann --with-python=3 --with-jsonc=system
+    --disable-riemann --disable-kafka --with-python=3 --with-jsonc=system
   make
 }
 

--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -9,7 +9,7 @@ url="https://www.syslog-ng.com/products/open-source-log-management/"
 license=('GPL2' 'LGPL2.1')
 depends=('awk' 'systemd-libs' 'glib2' 'libnsl' 'json-c' 'curl' 'libnet')
 makedepends=('libxslt' 'mongo-c-driver' 'librabbitmq-c' 'python' 'libesmtp' 'hiredis'
-             'libdbi' 'geoip' 'libmaxminddb' 'net-snmp')
+             'libdbi' 'geoip' 'libmaxminddb' 'net-snmp' 'librdkafka')
 checkdepends=('python-nose' 'python-pylint' 'python-ply')
 optdepends=('logrotate: for rotating log files'
             'libdbi: for the SQL plugin'
@@ -21,6 +21,7 @@ optdepends=('logrotate: for rotating log files'
             'geoip: for the GeoIP plugin'
             'libmaxminddb: for the GeoIP2 plugin'
             'net-snmp: for the SNMP plugin'
+            'librdkafka: for the Kafka C plugin'
             'python: for Python-based plugins')
 conflicts=('eventlog')
 replaces=('eventlog')
@@ -48,7 +49,7 @@ build() {
     --with-pidfile-dir=/run --enable-spoof-source --enable-ipv6 \
     --enable-systemd --with-systemdsystemunitdir=/usr/lib/systemd/system \
     --enable-manpages --enable-all-modules --disable-java --disable-java-modules  \
-    --disable-riemann --disable-kafka --with-python=3 --with-jsonc=system
+    --disable-riemann --with-python=3 --with-jsonc=system
   make
 }
 

--- a/trunk/PKGBUILD
+++ b/trunk/PKGBUILD
@@ -37,12 +37,6 @@ prepare() {
   cd $pkgname-$pkgver
   sed -i -e 's,/bin/,/usr/bin/,' -e 's,/sbin/,/bin/,' contrib/systemd/syslog-ng@.service
   sed -i -e 's|/var/run|/run|g' contrib/systemd/syslog-ng@default
-
-  # the version in pkg-config is 0.0.0 and so it won't detect the flags without
-  # this. since your version is newer this is an easy fix for now, but should
-  # eventually be removed when this bug is fixed:
-  # https://bugs.archlinux.org/task/61888
-  sed -i -e 's|^LMC_MIN_VERSION="1.0.0"|LMC_MIN_VERSION="0.0.0"|' configure.ac configure
 }
 
 build() {


### PR DESCRIPTION
This PR adds a new plugin (SNMP destination) and disables one as well (Kafka C destination) due to a missing dependency.

Please consider promoting [librdkafka (AUR)](https://aur.archlinux.org/packages/librdkafka/), its `PKGBUILD` is clean and short.